### PR TITLE
Ajuste al diseño del certificado Default de 4Geeks.com

### DIFF
--- a/auth/pdfStyles.js
+++ b/auth/pdfStyles.js
@@ -158,6 +158,13 @@ export const stylesDefaultPreview = {
         textAlign: "center",
         width:"100%"
     },
+    nameDefault4Geeks:{
+        position: "absolute",
+        left: "0%",
+        top: "57%",
+        textAlign: "center",
+        width:"100%"
+    },
     lastName:{
         fontSize:"36px", 
         fontWeight:300, 
@@ -174,6 +181,12 @@ export const stylesDefaultPreview = {
         width:"100%", 
         textAlign:"center"
     },
+    toDefault4Geeks:{
+        position:"absolute", 
+        top:"53%", 
+        width:"100%", 
+        textAlign:"center"
+    },
     givenTo:{
         fontSize:"18px", 
         fontWeight:300, 
@@ -182,6 +195,12 @@ export const stylesDefaultPreview = {
     completion:{
         position:"absolute", 
         top:"67%", 
+        width:"100%", 
+        textAlign:"center"
+    },
+    completionDefault4Geeks: {
+        position:"absolute", 
+        top:"63%", 
         width:"100%", 
         textAlign:"center"
     },

--- a/components/certificates/default.js
+++ b/components/certificates/default.js
@@ -10,6 +10,7 @@ const Certificate = ({ data }) => {
     }
     
     const styles = data.forPDF ? stylesDefault : stylesDefaultPreview;
+    const default4Geeks = data.layout?.slug == 'default-4geeks' && styles == stylesDefaultPreview
     
     return (
         <div style={styles.body} id={data.html}>
@@ -18,15 +19,23 @@ const Certificate = ({ data }) => {
                 <p style={styles.program}>{data.strings["Program"].toUpperCase()}</p>
                 <p style={styles.fullStack}>{"</"}{data.specialty.name.toUpperCase() || data.strings["Full Stack Software Development"].toUpperCase()}{">"}</p>
             </div>
-            <div id="to" style={styles.to}>
+            <div id="to" style={default4Geeks ? styles.toDefault4Geeks : styles.to}>
                 <span style={styles.givenTo}>{data.strings["Recognizes that"]}:</span>
             </div>
-            <div id="name" style={styles.name} >
+            <div id="name" style={default4Geeks ? styles.nameDefault4Geeks : styles.name} >
                 <span style={styles.firstName}>{"</"}{data.profile_academy?.first_name || data.user.first_name}</span>
                 <span style={styles.lastName}> {data.profile_academy?.last_name || data.user.last_name}{">"}</span>
             </div>
-            <div id="completion" style={styles.completion}>
-                <p style={styles.completionDescription}>{data.strings["Has successfully completed"] + " " + data.specialty.name.toUpperCase()}</p>
+            <div id="completion" style={default4Geeks ? styles.completionDefault4Geeks : styles.completion}>
+                {
+                    data.layout?.slug == 'default-4geeks' ?
+                    <>
+                        <p style={styles.completionDescription}>{data.strings["Has successfully completed"]}</p>
+                        <p style={styles.completionDescription}>{data.specialty.name.toUpperCase()}</p>
+                    </>
+                    :
+                    <p style={styles.completionDescription}>{data.strings["Has successfully completed"] + ' ' + data.specialty.name.toUpperCase()}</p>
+                }       
                 <p style={styles.completionDescription}>{data.cohort.syllabus_version.duration_in_hours}  {data.strings["Hours"] || "?"}</p>
                 <p style={styles.completionDescription}>{data.academy.name}</p>
                 <p style={styles.completionDescription}>{dayjs(data.issued_at || data.cohort.ending_date).locale(data.lang || "en").format("DD MMMM YYYY")}</p>


### PR DESCRIPTION
Issue: https://github.com/breatheco-de/breatheco-de/issues/9565

El cambio a los estilos del certificado en PDF solo requirió el salto de línea, ya que los estilos de los párrafos (que no eran iguales a como se muestra en la foto del issue), tenían ya propiedades que al agregar el salto de línea, hicieran que ya se viera el texto más centrado (la imagen azul del logo de 4Geeks del medio no se modificó ya que es parte del background)

Los estilos del preview del certificado son diferentes, y en estos sí hizo falta agregar nuevos estilos para alterar el posicionamiento de las letras